### PR TITLE
Guard husky prepare script to allow installs without Husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"format.check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
 		"types.check": "tsc --noEmit",
 		"local-ci": "node scripts/local-ci.js",
-		"prepare": "husky"
+                "prepare": "command -v husky >/dev/null 2>&1 && husky || true"
 	},
 	"dependencies": {
 		"@helia/strings": "^4.1.0",


### PR DESCRIPTION
## Summary
- guard the `prepare` script so install steps succeed even when Husky is not available

## Testing
- npm install --production

------
https://chatgpt.com/codex/tasks/task_e_68db5dc7ad98832eae4944164e3fe264