### PR TITLE
Fix: Update verifyMessage String Param

### DIFF
--- a/src/proposer.ts
+++ b/src/proposer.ts
@@ -572,7 +572,7 @@ async function handleIntention(
 
 	const verifyStartTime = Date.now()
 	const signerAddress = verifyMessage(
-		JSON.stringify(validatedIntention),
+		JSON.stringify(intention),
 		validatedSignature
 	)
 


### PR DESCRIPTION
## Summary
This PR updates the verifyMessage param to match the original address used to sign the message in the frontend.