### PR TITLE
🧼 Clean up `env` vars handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,8 +40,8 @@ BUNDLE_TRACKER_ADDRESS=0xF96cd74e7EEcb93a773105269b7ef5187db30aef
 # Must have sufficient ETH for gas fees on Sepolia
 # Format: 0x followed by 64 hex characters
 # NEVER share or commit the private key
-PROPOSER_ADDRESS=0xYourPublicKey
-TEST_PRIVATE_KEY=0xYourPrivateKeyHere
+PROPOSER_ADDRESS=0xYourPublicKeyHere
+PROPOSER_KEY=0xYourPrivateKeyHere
 
 # ─────────────────────────────────────────────────────────────────────────────
 # OPTIONAL CONFIGURATION

--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ ALCHEMY_API_KEY=your-32-character-alchemy-api-key
 # Current deployment: 0xF96cd74e7EEcb93a773105269b7ef5187db30aef
 BUNDLE_TRACKER_ADDRESS=0xF96cd74e7EEcb93a773105269b7ef5187db30aef
 
-# Public and Private key for the block proposer account
+# Public and Private key for the bundle proposer account
 # Must have sufficient ETH for gas fees on Sepolia
 # Format: 0x followed by 64 hex characters
 # NEVER share or commit the private key

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ BUNDLE_TRACKER_ADDRESS=your_bundle_tracker_contract_address
 
 # Public/Private key used by the bundle proposer for signing bundles (ensure this is kept secure)
 PROPOSER_ADDRESS=your_public_key
-TEST_PRIVATE_KEY=your_private_key
+PROPOSER_KEY=your_private_key
 ```
 
 (For testing purposes, you might also use a .env.test file.)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - DATABASE_URL=postgres://postgres:password@db:5432/node
       - ALCHEMY_API_KEY=your_alchemy_api_key
       - BUNDLE_TRACKER_ADDRESS=your_bundle_tracker_contract_address
-      - TEST_PRIVATE_KEY=your_private_key
+      - PROPOSER_KEY=your_private_key
     depends_on:
       - db
     volumes:

--- a/src/config/envSchema.ts
+++ b/src/config/envSchema.ts
@@ -84,7 +84,7 @@ export const envSchema: EnvVariable[] = [
 		transformer: (value) => ethers.getAddress(value),
 	},
 	{
-		name: 'TEST_PRIVATE_KEY',
+		name: 'PROPOSER_KEY',
 		required: true,
 		type: 'privateKey',
 		description: "Block proposer's private key",

--- a/src/proposer.ts
+++ b/src/proposer.ts
@@ -112,7 +112,7 @@ async function buildBundleTrackerContract(): Promise<BundleTrackerContract> {
  * Initializes wallet with private key for blockchain transactions.
  */
 async function buildAlchemyInstances() {
-	const { ALCHEMY_API_KEY, TEST_PRIVATE_KEY } = getEnvConfig()
+	const { ALCHEMY_API_KEY, PROPOSER_KEY } = getEnvConfig()
 	const mainnet = new Alchemy({
 		apiKey: ALCHEMY_API_KEY,
 		network: Network.ETH_MAINNET,
@@ -124,7 +124,7 @@ async function buildAlchemyInstances() {
 	await mainnet.core.getTokenMetadata(
 		'0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828'
 	)
-	const walletInstance = new Wallet(TEST_PRIVATE_KEY, sepolia)
+	const walletInstance = new Wallet(PROPOSER_KEY, sepolia)
 	return {
 		mainnetAlchemy: mainnet,
 		sepoliaAlchemy: sepolia,

--- a/src/proposer.ts
+++ b/src/proposer.ts
@@ -75,8 +75,6 @@ export interface BundleTrackerContract extends ethers.BaseContract {
 	): Promise<ethers.ContractTransaction>
 }
 
-const { PROPOSER_ADDRESS } = getEnvConfig()
-
 let cachedIntentions: ExecutionWrapper[] = []
 
 let mainnetAlchemy: Alchemy
@@ -308,6 +306,7 @@ async function saveBundleData(
 	cidToString: string,
 	proposerSignature: string
 ) {
+	const { PROPOSER_ADDRESS } = getEnvConfig()
 	// Convert the bundle (JSON) to a Buffer for the BYTEA column
 	const bundleBuffer = Buffer.from(JSON.stringify(bundleData.bundle), 'utf8')
 	await pool.query(
@@ -369,6 +368,7 @@ async function publishBundle(data: string, signature: string, from: string) {
 		timestamp: startTime,
 	})
 
+	const { PROPOSER_ADDRESS } = getEnvConfig()
 	if (validatedFrom !== PROPOSER_ADDRESS.toLowerCase()) {
 		throw new Error('Unauthorized: Only the proposer can publish new bundles.')
 	}
@@ -429,6 +429,7 @@ async function publishBundle(data: string, signature: string, from: string) {
 		)
 		logger.info('Blockchain transaction successful')
 		// Save proposer data after successful blockchain transaction.
+		const { PROPOSER_ADDRESS } = getEnvConfig()
 		await saveProposerData(PROPOSER_ADDRESS)
 	} catch (error) {
 		logger.error('Failed to propose bundle:', error)
@@ -506,6 +507,7 @@ async function updateBalances(
 	await initializeVault(validatedFrom)
 	await initializeVault(validatedTo)
 	const amountBigInt = safeBigInt(amount)
+	const { PROPOSER_ADDRESS } = getEnvConfig()
 	if (validatedFrom === PROPOSER_ADDRESS.toLowerCase()) {
 		const largeBalance = parseUnits('1000000000000', 18)
 		await updateBalance(
@@ -660,6 +662,7 @@ async function handleIntention(
 			if (amountReceived === undefined || !intention.to_token_address) {
 				throw new Error('Missing amountReceived or to_token_address for swap')
 			}
+			const { PROPOSER_ADDRESS } = getEnvConfig()
 			const swapInput = {
 				token: tokenAddress,
 				chainId: validatedIntention.from_token_chainid,
@@ -799,6 +802,7 @@ async function createAndPublishBundle() {
 	)
 	logger.info('Generated bundle proposer signature:', proposerSignature)
 	try {
+		const { PROPOSER_ADDRESS } = getEnvConfig()
 		await publishBundle(
 			JSON.stringify(bundleObject),
 			proposerSignature,

--- a/src/types/setup.ts
+++ b/src/types/setup.ts
@@ -69,7 +69,7 @@ export interface EnvironmentConfig {
 	/** Ethereum address of the bundle proposer */
 	PROPOSER_ADDRESS: string
 	/** Private key of the bundle proposer account */
-	TEST_PRIVATE_KEY: string
+	PROPOSER_KEY: string
 	/** Port number for the Express server (default: 3000) */
 	PORT: number
 	/** Logging verbosity level 0-6 (default: 3/info) */


### PR DESCRIPTION
As a follow-up to the runtime validation work and continuing our quest for a more maintainable codebase, this PR is a little housekeeping around `env` variables. A previous PR introduced a regression which resulted in the following warnings being triggered: 
```
[WARN] ⚠️  getEnvConfig() called before environment validation completed in index.ts
[WARN] Running fallback validation - this may indicate an initialization order issue
```

## Changes

  - I refactored the `PROPOSER_ADDRESS` initialization to use inline `getEnvConfig()` calls instead of module-level variables. The previous approach was causing  "environment validation not completed" warnings because modules were trying to access config before it was validated. Now each function grabs what it needs when it needs it and disposes when done.
  - Renamed `TEST_PRIVATE_KEY` to `PROPOSER_KEY` throughout the entire codebase. Having "TEST" in production variable names was confusing and inconsistent with our other PROPOSER_ADDRESS naming. Updated all references in code, docs, docker-compose, and examples.
  - Added log level-based obfuscation for sensitive environment variables. Instead of always showing partial obfuscation, we now adapt based on LOG_LEVEL:
    - SILLY (0): Shows full unobfuscated values for deep debugging
    - DEBUG (1-2): Shows last 4 characters like before (***xxxx)
    - INFO+ (3+): Fully obfuscates (********) for production safety

 decided to extract this into a dedicated `obfuscateSensitiveValue()` function to keep it maintainable.

  NOTE: So you don't accuse me of holding a double-standard, the obfuscation logic intentionally uses process.env.LOG_LEVEL directly rather than getEnvConfig() to avoid circular dependencies during the validation phase.   😁 Notice the warnings are still gone! Try to always use in-line calls to getEnvConfig - since it's cached, fast and disposable, it's not an antipattern to do so. It may look funny to your DRY eyes, tho lol.