### PR TITLE
🔧 Fix `module not found` error for `node-datachannel`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,21 @@ WORKDIR /usr/src/app
 
 # Copy package files and install dependencies
 COPY package.json bun.lockb* ./
-RUN bun install --production
 
-# Copy source code (no build step needed - Bun runs TS directly)
+# Download prebuilt native module for Alpine (avoids needing npm/build tools)
+# We manually download and extract the prebuilt native module of @ipshipyard/node-datachannel
+# We do this because it would normally be compiled but takes too long to build on Alpine
+RUN bun install --production && \
+    wget -q https://github.com/ipshipyard/js-node-datachannel/releases/download/v0.26.6/node-datachannel-v0.26.6-napi-v8-linuxmusl-x64.tar.gz && \
+    tar -xzf node-datachannel-v0.26.6-napi-v8-linuxmusl-x64.tar.gz -C node_modules/@ipshipyard/node-datachannel && \
+    rm node-datachannel-v0.26.6-napi-v8-linuxmusl-x64.tar.gz
+
+# Copy source code and CLI binary (no build step needed - Bun runs TS directly)
 COPY src ./src
+COPY bin ./bin
+
+# Link CLI globally
+RUN bun link
 
 # Expose the port
 EXPOSE 3000

--- a/scripts/download-native-modules.js
+++ b/scripts/download-native-modules.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env bun
+/**
+ * ╔═══════════════════════════════════════════════════════════════════════════╗
+ * ║                        🌪️  OYA PROTOCOL NODE  🌪️                          ║
+ * ║                    Native Module Download Script                          ║
+ * ╚═══════════════════════════════════════════════════════════════════════════╝
+ *
+ * Downloads prebuilt native modules for the current platform
+ * Right now this is only @ipfs/node-datachannel
+ */
+
+import { execSync } from 'child_process'
+import { existsSync } from 'fs'
+
+const PACKAGE = '@ipshipyard/node-datachannel'
+const VERSION = '0.26.6'
+const NAPI_VERSION = 'napi-v8'
+const targetDir = `node_modules/${PACKAGE}`
+
+// Check if npx is available
+let hasNpx = false
+try {
+	execSync('npx --version', { stdio: 'ignore' })
+	hasNpx = true
+} catch {
+	console.log('⚠️  npx not available, using curl + tar fallback')
+}
+
+try {
+	if (hasNpx) {
+		// Use npx prebuild-install (faster, handles everything)
+		execSync('npx -y prebuild-install -r napi', {
+			stdio: 'inherit',
+			cwd: targetDir,
+		})
+	} else {
+		// Fallback: download with curl
+		const platform =
+			process.platform === 'linux'
+				? 'linux'
+				: process.platform === 'darwin'
+					? 'darwin'
+					: 'win32'
+		const arch =
+			process.arch === 'x64'
+				? 'x64'
+				: process.arch === 'arm64'
+					? 'arm64'
+					: 'arm'
+
+		// For Linux, check if it's musl (Alpine) or glibc
+		const isMusl = platform === 'linux' && existsSync('/etc/alpine-release')
+		const platformVariant = isMusl ? 'linuxmusl' : platform
+
+		const binaryUrl = `https://github.com/ipshipyard/js-node-datachannel/releases/download/v${VERSION}/node-datachannel-v${VERSION}-${NAPI_VERSION}-${platformVariant}-${arch}.tar.gz`
+
+		execSync(`curl -sL ${binaryUrl} | tar -xz -C ${targetDir}`, {
+			stdio: 'pipe',
+		})
+	}
+} catch (error) {
+	console.error('❌ Failed to download native modules:', error.message)
+	process.exit(1)
+}

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -9,17 +9,22 @@
  */
 
 import { execSync } from 'child_process'
-import chalk from 'chalk'
+
+const chalk = await loadChalk()
 
 console.log(chalk.cyan('\n🌪️  Oya Node Setup\n'))
 
 try {
 	console.log(chalk.yellow('📦 Installing dependencies...'))
-	execSync('bun install', { stdio: 'inherit' })
+	execSync('bun install --silent', { stdio: 'pipe' })
 	console.log(chalk.green('✓ Dependencies installed\n'))
 
+	console.log(chalk.yellow('📦 Downloading native modules...'))
+	execSync('bun run scripts/download-native-modules.js', { stdio: 'inherit' })
+	console.log(chalk.green('✓ Native modules downloaded\n'))
+
 	console.log(chalk.yellow('🔗 Linking oya command globally...'))
-	execSync('bun link', { stdio: 'inherit' })
+	execSync('bun link', { stdio: 'pipe' })
 	console.log(chalk.green('✓ oya command linked\n'))
 
 	console.log(chalk.green.bold('🎉 Setup complete!\n'))
@@ -31,4 +36,25 @@ try {
 } catch (error) {
 	console.error(chalk.red('\n❌ Setup failed:'), error.message)
 	process.exit(1)
+}
+
+/**
+ * Loads chalk with fallback for when dependencies aren't installed yet
+ */
+async function loadChalk() {
+	try {
+		const module = await import('chalk')
+		return module.default
+	} catch {
+		// Fallback to plain console if chalk not installed yet
+		const identity = (s) => s
+		identity.bold = identity
+		return {
+			cyan: identity,
+			yellow: identity,
+			green: identity,
+			red: identity,
+			gray: identity,
+		}
+	}
 }


### PR DESCRIPTION
  ## Summary

This PR solves build issues related to the migration from Node JS runtime to Bun (#19 ). It creates a scripted process and some improvements in UX for our setup. `bun setup` has been improved to build all required dependencies. Going forward, we _may_ want to prioritize Docker as the premier way that users set up a node, since our docker set up is extremely fast / lightweight (uses Alpine Linux) and eliminates the platform setup overhead that comes with running/building from scratch. 

## Offending Error
`@helia/ipfs` uses `libp2p` which uses `node-datachannel` which is really NodeJS bindings for native C code that handles WebRTC. Switching to Bun in #19 means that we eliminated our compile time step and thus obliterated the package from our final build. This was undetected previously because `node_modules` was never completely cleared on the machines I tested from, so the binary was already built when running bun. 
<img width="2048" height="991" alt="image" src="https://github.com/user-attachments/assets/824dd3bd-d23a-465a-849c-abfaacaef9ac" />

## Solution
Some attempted/tested solutions were the following:

1. **disable WebRTC features in Helia setup/configuration**, thereby obviating the need for the dep, but that could have incurred significant performance penalties for the node.
2. **Use `npm install` to compile the offending package** - however, this drags an entire `nodejs` and `npm` dependency into the picture. Introducing NodeJS as a dependency after eliminating it would be a regression (albeit probably excusable on some level due to its omnipresence). The real problem is that doing so would SLOW down docker builds and reduce the crazy speed gains we get from using bun. 
3. **Use `npx install` to compile the offending package** - although this is significantly faster than all the other options, it requires `npm` dependency which could be lengthy install on a fresh machine. 
4. **Grab the binaries ourselves and handle their placement** - we get it straight from github releases and put it in node modules via script. 1) it is fast in all scenarios, 2) it involves no magic or hidden logic, 3) it is easily changeable and upgradeable, 4) it requires no additional dependencies

So the ultimate solution was to check if the user has `npx` - use it if available and if not (i.e. Solution 3, first, then Solution 4 as fallback). For sake of simplicity and avoiding additional start up overhead, on the docker image, we just use route 4.


  ## Changes
  - **New download script** (`scripts/download-native-modules.js`) that grabs prebuilt `node-datachannel` binaries
    - Uses `npx` if available (fastest)
    - Falls back to `curl`/`tar` if not
    - Auto-detects platform and architecture (handles `musl` vs `glibc` on Linux)
  - **Updated setup script** to call the download script and suppress verbose output
  - **Optimized Dockerfile** to download the prebuilt binary for Alpine & to correctly link the oya CLI
  - **Updated README** with new prerequisites and clearer setup instructions(⚠️  this still needs work IMO)

  ## Why?
  The `@ipshipyard/node-datachannel` package is a native C++ module that normally needs to be compiled during installation. This was causing:
  - Errors when using only bun
  - Long build times/error states in Docker when combing npm and bun
  - Need for build dependencies (cmake, python, g++) when building from scratch
  - Additional overhead and complexity from our previous clean setup

  ## Test plan
  - [x] Fresh `bun run setup` on local machine (with npm)
  - [x] Fresh `bun run setup` without npm (curl fallback)
  - [x] Docker build completes successfully
  - [x] App runs without "Cannot find module" errors