### PR TITLE
✍🏿 Add Debug Mode Endpoint Logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,21 +16,12 @@ import bppkg from 'body-parser'
 import pgpkg from 'pg'
 
 import { displayBanner } from './utils/banner.js'
-import { logger, diagnostic } from './utils/logger.js'
+import { logger, diagnostic, logAvailableEndpoints } from './utils/logger.js'
 import { setupEnvironment } from './utils/env.js'
 import { initializeDatabase } from './utils/database.js'
 import { registerShutdownHandlers } from './utils/gracefulShutdown.js'
 import type { DatabaseHealthMonitor } from './utils/database.js'
-import {
-	bundleRouter,
-	cidRouter,
-	balanceRouter,
-	vaultNonceRouter,
-	healthRouter,
-	infoRouter,
-	metricsRouter,
-	intentionRouter,
-} from './routes.js'
+import { routeMounts } from './routes.js'
 import { createAndPublishBundle, initializeProposer } from './proposer.js'
 import { bearerAuth } from './auth.js'
 
@@ -153,15 +144,13 @@ try {
 
 // Mount route handlers
 logger.debug('Mounting route handlers')
-app.use('/health', healthRouter)
-app.use('/info', infoRouter)
-app.use('/metrics', metricsRouter)
-app.use('/intention', intentionRouter)
-app.use('/bundle', bundleRouter)
-app.use('/cid', cidRouter)
-app.use('/balance', balanceRouter)
-app.use('/nonce', vaultNonceRouter)
+for (const { basePath, router } of routeMounts) {
+	app.use(basePath, router)
+}
 logger.debug('All routes mounted successfully')
+
+// Log available endpoints in debug mode
+logAvailableEndpoints(routeMounts)
 
 /*
 ╔═══════════════════════════════════════════════════════════════════════════╗

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -19,6 +19,7 @@
  */
 
 import { Router } from 'express'
+import type { RouteMount } from './types/routes.js'
 import {
 	saveBundle,
 	getBundle,
@@ -37,51 +38,58 @@ import {
 	submitIntention,
 } from './controllers.js'
 
-const bundleRouter = Router()
-const cidRouter = Router()
-const balanceRouter = Router()
-const vaultNonceRouter = Router()
-const healthRouter = Router()
-const infoRouter = Router()
-const metricsRouter = Router()
-const intentionRouter = Router()
-
-// Bundle routes
-bundleRouter.post('/', saveBundle)
-bundleRouter.get('/:nonce', getBundle)
-bundleRouter.get('/', getAllBundles)
-
-// CID routes
-cidRouter.post('/', saveCID)
-cidRouter.get('/:nonce', getCIDsByNonce)
-
-// Balance routes
-balanceRouter.post('/', updateBalanceForOneToken)
-balanceRouter.get('/:vault/:token', getBalanceForOneToken)
-balanceRouter.get('/:vault', getBalanceForAllTokens)
-
-// Vault nonce routes
-vaultNonceRouter.get('/:vault', getVaultNonce)
-vaultNonceRouter.post('/:vault', setVaultNonce)
-
-// Health and info routes
-healthRouter.get('/detailed', detailedHealthCheck)
-healthRouter.get('/', healthCheck)
-infoRouter.get('/', getInfo)
-
-// Metrics routes
-metricsRouter.get('/', getMetrics)
-
-// Intention routes
-intentionRouter.post('/', submitIntention)
-
-export {
-	bundleRouter,
-	cidRouter,
-	balanceRouter,
-	vaultNonceRouter,
-	healthRouter,
-	infoRouter,
-	metricsRouter,
-	intentionRouter,
-}
+/**
+ * Route mount configuration
+ *
+ * Single source of truth for all route mounts. Used by:
+ * - index.ts to mount routes on the Express app
+ * - logger.ts to display available endpoints
+ *
+ * Each router is defined inline and configured with its routes.
+ *
+ * @public
+ */
+export const routeMounts: RouteMount[] = [
+	{
+		basePath: '/health',
+		router: Router()
+			.get('/', healthCheck)
+			.get('/detailed', detailedHealthCheck),
+	},
+	{
+		basePath: '/info',
+		router: Router().get('/', getInfo),
+	},
+	{
+		basePath: '/metrics',
+		router: Router().get('/', getMetrics),
+	},
+	{
+		basePath: '/intention',
+		router: Router().post('/', submitIntention),
+	},
+	{
+		basePath: '/bundle',
+		router: Router()
+			.post('/', saveBundle)
+			.get('/:nonce', getBundle)
+			.get('/', getAllBundles),
+	},
+	{
+		basePath: '/cid',
+		router: Router().post('/', saveCID).get('/:nonce', getCIDsByNonce),
+	},
+	{
+		basePath: '/balance',
+		router: Router()
+			.post('/', updateBalanceForOneToken)
+			.get('/:vault/:token', getBalanceForOneToken)
+			.get('/:vault', getBalanceForAllTokens),
+	},
+	{
+		basePath: '/nonce',
+		router: Router()
+			.get('/:vault', getVaultNonce)
+			.post('/:vault', setVaultNonce),
+	},
+]

--- a/src/types/routes.ts
+++ b/src/types/routes.ts
@@ -1,0 +1,47 @@
+/**
+ * ╔═══════════════════════════════════════════════════════════════════════════╗
+ * ║                        🌪️  OYA PROTOCOL NODE  🌪️                          ║
+ * ║                          Route Type Definitions                           ║
+ * ╚═══════════════════════════════════════════════════════════════════════════╝
+ *
+ * TypeScript type definitions for Express route configuration and logging.
+ *
+ * @packageDocumentation
+ */
+
+import type { Router } from 'express'
+
+/**
+ * Route mount configuration
+ *
+ * Represents a mounted Express router with its base path.
+ */
+export interface RouteMount {
+	basePath: string
+	router: Router
+}
+
+/**
+ * Endpoint information extracted from Express router
+ *
+ * Contains metadata about an API endpoint including its HTTP method,
+ * path, and authentication requirements.
+ */
+export interface EndpointInfo {
+	method: string
+	path: string
+	protected: boolean
+}
+
+/**
+ * Express router layer internal structure
+ *
+ * Represents the internal structure of Express router layers.
+ * Used for extracting route information from the router stack.
+ */
+export interface RouterLayer {
+	route?: {
+		path: string
+		methods: Record<string, boolean>
+	}
+}


### PR DESCRIPTION
This PR adds debug-mode endpoint logging and refactors our route configuration to be DRY.

<img width="1268" height="523" alt="image" src="https://github.com/user-attachments/assets/fb0ccbdb-8c66-4bd2-8f77-f579591c46d9" />

I added a utility that logs all registered endpoints at startup when running in debug mode (LOG_LEVEL=2). Each endpoint shows its HTTP method, path, and whether it's protected with bearer auth. This follows tasks outlined for completion in #20.

I noticed we were defining routes in multiple places (individual router constants, mounting them one by one in index.ts), so I refactored everything to use a single `routeMounts` array. Now there's one source of truth for all route definitions - routers are created inline, and we just loop through to mount them.

Note: The protection detection is currently hardcoded to assume all POST endpoints are bearer-protected (which matches our global middleware). I added comments so we remember to update it if the auth strategy changes.