### PR TITLE
📜  Add `_test` db scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ API_BEARER_TOKEN=your-secret-bearer-token-at-least-32-characters-long
 # Format: postgresql://[user]:[password]@[host]:[port]/[database]
 DATABASE_URL=postgresql://user:password@localhost:5432/oya_db
 
+# Test database connection string (optional)
+# If not set, will auto-derive from DATABASE_URL by appending '_test' to database name
+# TEST_DATABASE_URL=postgresql://user:password@localhost:5432/oya_db_test
+
 # Enable SSL for database connections (default: true)
 # Set to false for local development databases without SSL
 # DATABASE_SSL=true

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ PROPOSER_ADDRESS=your_public_key
 PROPOSER_KEY=your_private_key
 ```
 
-(For testing purposes, you might also use a .env.test file.)
+See `.env.example` for a complete list of available configuration options including optional variables like `PORT`, `LOG_LEVEL`, `DATABASE_SSL`, and `DIAGNOSTIC_LOGGER`.
 
 ## Database Setup
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
 		"db:create": "bun run scripts/create-db.js",
 		"db:setup": "bun run scripts/setup-db.js",
 		"db:reset": "FORCE_DROP=true bun run scripts/setup-db.js --drop-existing",
+		"db:test:create": "bun run scripts/create-test-db.js",
+		"db:test:setup": "bun run scripts/setup-test-db.js",
+		"db:test:reset": "FORCE_DROP=true bun run scripts/setup-test-db.js --drop-existing",
 		"prepare": "command -v husky >/dev/null 2>&1 && husky || true"
 	},
 	"dependencies": {

--- a/scripts/create-db.js
+++ b/scripts/create-db.js
@@ -13,19 +13,12 @@
  *   DATABASE_URL=postgres://... bun run scripts/create-db.js  # Override connection string
  */
 
-import pg from 'pg'
 import dotenv from 'dotenv'
 import chalk from 'chalk'
-import { fileURLToPath } from 'url'
-import path from 'path'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
+import { createDatabase } from './shared/db-create.js'
 
 // Load environment variables
 dotenv.config()
-
-const { Client } = pg
 
 // Parse command line arguments
 const args = process.argv.slice(2)
@@ -57,110 +50,13 @@ ${chalk.yellow('Note:')} This script will always create a database named 'oya_db
 // Fixed database name for Oya
 const DB_NAME = 'oya_db'
 
-// Extract connection parameters from DATABASE_URL or use defaults
-function getConnectionParams() {
-	let host = 'localhost'
-	let port = 5432
-	let user = 'postgres'
-	let password = 'postgres'
-
-	if (process.env.DATABASE_URL) {
-		try {
-			const url = new URL(process.env.DATABASE_URL)
-			host = url.hostname || host
-			port = url.port ? parseInt(url.port) : port
-			user = url.username || user
-			password = url.password || password
-		} catch (e) {
-			console.warn(chalk.yellow('Warning: Could not parse DATABASE_URL, using defaults'))
-		}
-	}
-
-	return { host, port, user, password }
-}
-
-/**
- * Main function to create the oya_db database
- */
-async function createDatabase() {
-	console.log(chalk.cyan('\n🌪️  Oya Node Database Creation\n'))
-
-	const { host, port, user, password } = getConnectionParams()
-
-	console.log(chalk.gray(`Target database: ${DB_NAME}`))
-	console.log(chalk.gray(`Server: ${host}:${port}`))
-	console.log(chalk.gray(`User: ${user}\n`))
-
-	// Connect to the default 'postgres' database
-	const client = new Client({
-		host,
-		port,
-		user,
-		password,
-		database: 'postgres', // Connect to default database
-	})
-
-	try {
-		// Test connection
-		console.log(chalk.yellow('Connecting to PostgreSQL server...'))
-		await client.connect()
-		console.log(chalk.green('✓ Connected to PostgreSQL\n'))
-
-		// Check if database already exists
-		console.log(chalk.yellow(`Checking if database '${DB_NAME}' exists...`))
-		const checkResult = await client.query(
-			`SELECT 1 FROM pg_database WHERE datname = $1`,
-			[DB_NAME]
-		)
-
-		if (checkResult.rows.length > 0) {
-			console.log(chalk.green(`✓ Database '${DB_NAME}' already exists`))
-			console.log(chalk.cyan('\nDatabase is ready! You can now run:'))
-			console.log(chalk.gray(`  bun run db:setup`))
-			console.log(chalk.gray(`\nTo create/update tables\n`))
-			process.exit(0)
-		}
-
-		// Create the database
-		console.log(chalk.yellow(`Creating database '${DB_NAME}'...`))
-		await client.query(`CREATE DATABASE ${DB_NAME}`)
-		console.log(chalk.green(`✓ Database '${DB_NAME}' created successfully!\n`))
-
-		// Show next steps
-		const suggestedUrl = `postgresql://${user}:${password}@${host}:${port}/${DB_NAME}`
-
-		console.log(chalk.cyan('🎉 Database created successfully!\n'))
-		console.log(chalk.yellow('Next steps:'))
-		console.log(chalk.gray('1. Ensure your .env file has:'))
-		console.log(chalk.gray(`   DATABASE_URL=${suggestedUrl}`))
-		console.log(chalk.gray('\n2. Create the tables:'))
-		console.log(chalk.gray(`   bun run db:setup\n`))
-
-	} catch (error) {
-		console.error(chalk.red('\n❌ Database creation failed:'))
-		console.error(chalk.red(error.message))
-
-		if (error.code === 'ECONNREFUSED') {
-			console.log(chalk.yellow('\nMake sure PostgreSQL is running and accessible'))
-			console.log(chalk.gray('You may need to:'))
-			console.log(chalk.gray('  - Start PostgreSQL service'))
-			console.log(chalk.gray('  - Check your connection settings'))
-			console.log(chalk.gray('  - Verify user credentials'))
-		} else if (error.code === '42P04') {
-			console.log(chalk.yellow(`\nDatabase '${DB_NAME}' already exists`))
-		} else if (error.code === '28P01') {
-			console.log(chalk.yellow('\nAuthentication failed'))
-			console.log(chalk.gray('Check your username and password'))
-		}
-
-		process.exit(1)
-	} finally {
-		await client.end()
-	}
-}
-
-// Run the creation
-createDatabase().catch(error => {
+// Run creation
+createDatabase({
+	dbName: DB_NAME,
+	connectionString: process.env.DATABASE_URL,
+	environment: 'production',
+	nextStepCommand: 'bun run db:setup'
+}).catch(error => {
 	console.error(chalk.red('Unexpected error:'), error)
 	process.exit(1)
 })

--- a/scripts/create-test-db.js
+++ b/scripts/create-test-db.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+/**
+ * ╔═══════════════════════════════════════════════════════════════════════════╗
+ * ║                        🌪️  OYA PROTOCOL NODE  🌪️                          ║
+ * ║                    Test Database Creation Script                          ║
+ * ╚═══════════════════════════════════════════════════════════════════════════╝
+ *
+ * This script creates the test PostgreSQL database if it doesn't exist.
+ * It connects to the 'postgres' default database to create the test database.
+ *
+ * Usage:
+ *   bun run scripts/create-test-db.js                    # Creates test database using connection from TEST_DATABASE_URL or DATABASE_URL
+ *   TEST_DATABASE_URL=postgres://... bun run scripts/create-test-db.js  # Override connection string
+ */
+
+import dotenv from 'dotenv'
+import chalk from 'chalk'
+import { createDatabase } from './shared/db-create.js'
+
+// Load environment variables
+dotenv.config()
+
+// Parse command line arguments
+const args = process.argv.slice(2)
+const showHelp = args.includes('--help') || args.includes('-h')
+
+if (showHelp) {
+	console.log(`
+${chalk.cyan('Oya Node Test Database Creation Script')}
+
+${chalk.yellow('Usage:')}
+  bun run db:test:create                      # Creates test database
+  bun run scripts/create-test-db.js --help    # Show this help message
+
+${chalk.yellow('Environment:')}
+  TEST_DATABASE_URL - PostgreSQL connection string for test database (optional)
+  DATABASE_URL      - Used to derive test database if TEST_DATABASE_URL not set
+
+${chalk.yellow('Examples:')}
+  # Using .env file (with TEST_DATABASE_URL or DATABASE_URL set)
+  bun run db:test:create
+
+  # Override connection
+  TEST_DATABASE_URL=postgresql://user:pass@localhost:5432/oya_db_test bun run scripts/create-test-db.js
+
+${chalk.yellow('Note:')} If TEST_DATABASE_URL is not set, this script will derive it from DATABASE_URL
+by appending '_test' to the database name.
+`)
+	process.exit(0)
+}
+
+/**
+ * Get test database connection string and name
+ */
+function getTestDatabaseConfig() {
+	let testDatabaseUrl = process.env.TEST_DATABASE_URL
+
+	// If not set, try to derive from DATABASE_URL
+	if (!testDatabaseUrl && process.env.DATABASE_URL) {
+		const prodUrl = process.env.DATABASE_URL
+		// Replace database name with _test suffix
+		testDatabaseUrl = prodUrl.replace(/\/([^/]+)(\?|$)/, '/$1_test$2')
+		console.log(chalk.yellow(`ℹ️  TEST_DATABASE_URL not set, derived from DATABASE_URL`))
+	}
+
+	if (!testDatabaseUrl) {
+		console.error(chalk.red('❌ Error: Neither TEST_DATABASE_URL nor DATABASE_URL is set'))
+		console.log(chalk.yellow('Please set one of these in your .env file'))
+		console.log(chalk.gray('Example: TEST_DATABASE_URL=postgresql://user:password@localhost:5432/oya_db_test'))
+		process.exit(1)
+	}
+
+	// Extract database name from URL
+	try {
+		const url = new URL(testDatabaseUrl)
+		const dbName = url.pathname.substring(1) // Remove leading '/'
+		return { connectionString: testDatabaseUrl, dbName }
+	} catch (e) {
+		console.error(chalk.red('Error parsing connection URL:'), e.message)
+		process.exit(1)
+	}
+}
+
+// Get test database configuration
+const { connectionString, dbName } = getTestDatabaseConfig()
+
+// Run creation
+createDatabase({
+	dbName,
+	connectionString,
+	environment: 'test',
+	nextStepCommand: 'bun run db:test:setup'
+}).catch(error => {
+	console.error(chalk.red('Unexpected error:'), error)
+	process.exit(1)
+})

--- a/scripts/setup-db.js
+++ b/scripts/setup-db.js
@@ -14,20 +14,12 @@
  *   bun run scripts/setup-db.js --drop-existing    # Drop and recreate all tables (DESTRUCTIVE!)
  */
 
-import pg from 'pg'
 import dotenv from 'dotenv'
 import chalk from 'chalk'
-import { fileURLToPath } from 'url'
-import path from 'path'
-import fs from 'fs'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
+import { setupDatabase } from './shared/db-setup.js'
 
 // Load environment variables
 dotenv.config()
-
-const { Pool } = pg
 
 // Parse command line arguments
 const args = process.argv.slice(2)
@@ -50,6 +42,9 @@ ${chalk.yellow('Direct usage:')}
 
 ${chalk.yellow('Required Environment:')}
   DATABASE_URL - PostgreSQL connection string
+
+${chalk.yellow('Environment Variables (optional):')}
+  DATABASE_SSL - Enable/disable SSL (default: true for production)
 
 ${chalk.yellow('Tables Created:')}
   - bundles   : Stores bundle data with IPFS CIDs
@@ -77,175 +72,17 @@ if (!process.env.DATABASE_URL) {
 	process.exit(1)
 }
 
-// Determine SSL setting
+// Determine SSL setting (default to true for production)
 const DATABASE_SSL = process.env.DATABASE_SSL !== 'false'
 
-// Create connection pool
-const pool = new Pool({
+// Run setup
+setupDatabase({
 	connectionString: process.env.DATABASE_URL,
-	ssl: DATABASE_SSL ? { rejectUnauthorized: false } : false,
-})
-
-/**
- * SQL statements for creating tables
- */
-const createTablesSql = `
--- Create the bundles table (stores bundle data with IPFS CIDs)
-CREATE TABLE IF NOT EXISTS bundles (
-  id SERIAL PRIMARY KEY,
-  bundle BYTEA NOT NULL,
-  nonce INTEGER NOT NULL,
-  proposer TEXT NOT NULL,
-  signature TEXT NOT NULL,
-  ipfs_cid TEXT,
-  timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
-);
-
--- Create the cids table (tracks submitted CIDs)
-CREATE TABLE IF NOT EXISTS cids (
-  id SERIAL PRIMARY KEY,
-  cid TEXT NOT NULL,
-  nonce INTEGER NOT NULL,
-  proposer TEXT NOT NULL,
-  timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
-);
-
--- Create the balances table (manages vault token balances)
-CREATE TABLE IF NOT EXISTS balances (
-  id SERIAL PRIMARY KEY,
-  vault TEXT NOT NULL,
-  token TEXT NOT NULL,
-  balance NUMERIC(78, 18) NOT NULL,
-  timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-  UNIQUE (vault, token)
-);
-
--- Create the nonces table (tracks vault nonces)
-CREATE TABLE IF NOT EXISTS nonces (
-  id SERIAL PRIMARY KEY,
-  vault TEXT NOT NULL,
-  nonce INTEGER NOT NULL,
-  timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-  UNIQUE (vault)
-);
-
--- Create the proposers table (records block proposers)
-CREATE TABLE IF NOT EXISTS proposers (
-  id SERIAL PRIMARY KEY,
-  proposer TEXT NOT NULL UNIQUE,
-  last_seen TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
-);
-`
-
-/**
- * SQL statements for creating indexes
- */
-const createIndexesSql = `
--- Create case-insensitive unique indexes for vault/token lookups
-CREATE UNIQUE INDEX IF NOT EXISTS unique_lower_vault_nonces ON nonces (LOWER(vault));
-CREATE UNIQUE INDEX IF NOT EXISTS unique_lower_vault_token_balances ON balances (LOWER(vault), LOWER(token));
-`
-
-/**
- * SQL statements for dropping tables (when --drop-existing is used)
- */
-const dropTablesSql = `
-DROP TABLE IF EXISTS bundles CASCADE;
-DROP TABLE IF EXISTS cids CASCADE;
-DROP TABLE IF EXISTS balances CASCADE;
-DROP TABLE IF EXISTS nonces CASCADE;
-DROP TABLE IF EXISTS proposers CASCADE;
-`
-
-/**
- * Main setup function
- */
-async function setupDatabase() {
-	console.log(chalk.cyan('\n🌪️  Oya Node Database Setup\n'))
-	console.log(chalk.gray(`Connection: ${process.env.DATABASE_URL.replace(/:[^:@]*@/, ':****@')}`))
-	console.log(chalk.gray(`SSL: ${DATABASE_SSL ? 'enabled' : 'disabled'}\n`))
-
-	try {
-		// Test connection
-		console.log(chalk.yellow('Testing database connection...'))
-		await pool.query('SELECT NOW()')
-		console.log(chalk.green('✓ Database connection successful\n'))
-
-		// Drop existing tables if requested
-		if (shouldDropExisting) {
-			console.log(chalk.red('⚠️  Dropping existing tables...'))
-			const confirmDrop = process.env.FORCE_DROP === 'true'
-
-			if (!confirmDrop) {
-				console.log(chalk.red('\n⚠️  WARNING: This will DELETE ALL DATA in the following tables:'))
-				console.log(chalk.red('  - bundles, cids, balances, nonces, proposers'))
-				console.log(chalk.yellow('\nTo confirm, set FORCE_DROP=true or remove --drop-existing flag'))
-				process.exit(1)
-			}
-
-			await pool.query(dropTablesSql)
-			console.log(chalk.green('✓ Existing tables dropped\n'))
-		}
-
-		// Create tables
-		console.log(chalk.yellow('Creating tables...'))
-		await pool.query(createTablesSql)
-		console.log(chalk.green('✓ Tables created successfully'))
-
-		// Create indexes
-		console.log(chalk.yellow('Creating indexes...'))
-		await pool.query(createIndexesSql)
-		console.log(chalk.green('✓ Indexes created successfully'))
-
-		// Verify tables were created
-		console.log(chalk.yellow('\nVerifying database schema...'))
-		const result = await pool.query(`
-			SELECT table_name
-			FROM information_schema.tables
-			WHERE table_schema = 'public'
-			AND table_name IN ('bundles', 'cids', 'balances', 'nonces', 'proposers')
-			ORDER BY table_name
-		`)
-
-		console.log(chalk.green('\n✓ Database setup complete!'))
-		console.log(chalk.cyan('\nTables created:'))
-		result.rows.forEach(row => {
-			console.log(chalk.gray(`  • ${row.table_name}`))
-		})
-
-		// Check if we need to update existing data to lowercase
-		const balancesCount = await pool.query('SELECT COUNT(*) FROM balances')
-		const noncesCount = await pool.query('SELECT COUNT(*) FROM nonces')
-
-		if (parseInt(balancesCount.rows[0].count) > 0 || parseInt(noncesCount.rows[0].count) > 0) {
-			console.log(chalk.yellow('\nUpdating existing data to lowercase...'))
-			await pool.query('UPDATE nonces SET vault = LOWER(vault)')
-			await pool.query('UPDATE balances SET vault = LOWER(vault), token = LOWER(token)')
-			console.log(chalk.green('✓ Existing data updated'))
-		}
-
-		console.log(chalk.green('\n✅ Database is ready for use!\n'))
-
-	} catch (error) {
-		console.error(chalk.red('\n❌ Database setup failed:'))
-		console.error(chalk.red(error.message))
-
-		if (error.code === 'ECONNREFUSED') {
-			console.log(chalk.yellow('\nMake sure PostgreSQL is running and accessible'))
-		} else if (error.code === '42P07') {
-			console.log(chalk.yellow('\nTables already exist. Use --drop-existing to recreate them'))
-		} else if (error.code === '3D000') {
-			console.log(chalk.yellow('\nDatabase does not exist. Please create it first'))
-		}
-
-		process.exit(1)
-	} finally {
-		await pool.end()
-	}
-}
-
-// Run the setup
-setupDatabase().catch(error => {
+	ssl: DATABASE_SSL,
+	dropExisting: shouldDropExisting,
+	forceDropConfirm: process.env.FORCE_DROP === 'true',
+	environment: 'production'
+}).catch(error => {
 	console.error(chalk.red('Unexpected error:'), error)
 	process.exit(1)
 })

--- a/scripts/setup-test-db.js
+++ b/scripts/setup-test-db.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env bun
+/**
+ * ╔═══════════════════════════════════════════════════════════════════════════╗
+ * ║                        🌪️  OYA PROTOCOL NODE  🌪️                          ║
+ * ║                       Test Database Setup Script                          ║
+ * ╚═══════════════════════════════════════════════════════════════════════════╝
+ *
+ * This script creates all necessary database tables for testing.
+ * It can be run safely multiple times as it uses IF NOT EXISTS clauses.
+ *
+ * Usage:
+ *   bun run scripts/setup-test-db.js                    # Uses TEST_DATABASE_URL from .env
+ *   TEST_DATABASE_URL=postgres://... bun run scripts/setup-test-db.js  # Override connection string
+ *   bun run scripts/setup-test-db.js --drop-existing    # Drop and recreate all tables (DESTRUCTIVE!)
+ */
+
+import dotenv from 'dotenv'
+import chalk from 'chalk'
+import { setupDatabase } from './shared/db-setup.js'
+
+// Load environment variables
+dotenv.config()
+
+// Parse command line arguments
+const args = process.argv.slice(2)
+const shouldDropExisting = args.includes('--drop-existing')
+const showHelp = args.includes('--help') || args.includes('-h')
+
+if (showHelp) {
+	console.log(`
+${chalk.cyan('Oya Node Test Database Setup Script')}
+
+${chalk.yellow('Usage:')}
+  bun run db:test:setup                       # Uses TEST_DATABASE_URL from .env
+  bun run db:test:reset                       # Drop and recreate all tables (DESTRUCTIVE!)
+  bun run scripts/setup-test-db.js --help     # Show this help message
+
+${chalk.yellow('Direct usage:')}
+  bun run scripts/setup-test-db.js                 # Uses TEST_DATABASE_URL from .env
+  TEST_DATABASE_URL=postgres://... bun run scripts/setup-test-db.js  # Override connection string
+  bun run scripts/setup-test-db.js --drop-existing # Drop and recreate all tables
+
+${chalk.yellow('Required Environment:')}
+  TEST_DATABASE_URL - PostgreSQL connection string for test database
+
+${chalk.yellow('Environment Variables (optional):')}
+  TEST_DATABASE_URL - Defaults to DATABASE_URL with '_test' appended to db name
+  DATABASE_SSL      - Enable/disable SSL (default: false for tests)
+
+${chalk.yellow('Tables Created:')}
+  - bundles   : Stores bundle data with IPFS CIDs
+  - cids      : Tracks submitted CIDs
+  - balances  : Manages vault token balances
+  - nonces    : Tracks vault nonces
+  - proposers : Records block proposers
+
+${chalk.red('Warning:')} Using --drop-existing will DELETE ALL EXISTING DATA!
+`)
+	process.exit(0)
+}
+
+// Get test database URL
+let testDatabaseUrl = process.env.TEST_DATABASE_URL
+
+// If not set, try to derive from DATABASE_URL
+if (!testDatabaseUrl && process.env.DATABASE_URL) {
+	const prodUrl = process.env.DATABASE_URL
+	// Replace database name with _test suffix
+	testDatabaseUrl = prodUrl.replace(/\/([^/]+)(\?|$)/, '/$1_test$2')
+	console.log(chalk.yellow(`ℹ️  TEST_DATABASE_URL not set, using derived URL from DATABASE_URL`))
+}
+
+if (!testDatabaseUrl) {
+	console.error(
+		chalk.red('❌ Error: TEST_DATABASE_URL environment variable is not set')
+	)
+	console.log(
+		chalk.yellow('Please set TEST_DATABASE_URL in your .env file or environment')
+	)
+	console.log(
+		chalk.gray('Example: TEST_DATABASE_URL=postgresql://user:password@localhost:5432/oya_db_test')
+	)
+	console.log(
+		chalk.gray('Or set DATABASE_URL and it will automatically append _test to the database name')
+	)
+	process.exit(1)
+}
+
+// Determine SSL setting (default to false for test databases)
+const DATABASE_SSL = process.env.DATABASE_SSL === 'true'
+
+// Run setup
+setupDatabase({
+	connectionString: testDatabaseUrl,
+	ssl: DATABASE_SSL,
+	dropExisting: shouldDropExisting,
+	forceDropConfirm: process.env.FORCE_DROP === 'true',
+	environment: 'test'
+}).catch(error => {
+	console.error(chalk.red('Unexpected error:'), error)
+	process.exit(1)
+})

--- a/scripts/shared/db-create.js
+++ b/scripts/shared/db-create.js
@@ -1,0 +1,141 @@
+/**
+ * ╔═══════════════════════════════════════════════════════════════════════════╗
+ * ║                        🌪️  OYA PROTOCOL NODE  🌪️                          ║
+ * ║                  Shared Database Creation Logic                           ║
+ * ╚═══════════════════════════════════════════════════════════════════════════╝
+ *
+ * Shared functions for database creation used by both production and test scripts.
+ */
+
+import pg from 'pg'
+import chalk from 'chalk'
+
+const { Client } = pg
+
+/**
+ * Extract connection parameters from a connection string
+ *
+ * @param {string} connectionString - PostgreSQL connection string
+ * @returns {object} Connection parameters (host, port, user, password)
+ */
+export function parseConnectionParams(connectionString) {
+	const defaults = {
+		host: 'localhost',
+		port: 5432,
+		user: 'postgres',
+		password: 'postgres',
+	}
+
+	if (!connectionString) {
+		return defaults
+	}
+
+	try {
+		const url = new URL(connectionString)
+		return {
+			host: url.hostname || defaults.host,
+			port: url.port ? parseInt(url.port) : defaults.port,
+			user: url.username || defaults.user,
+			password: url.password || defaults.password,
+		}
+	} catch (e) {
+		console.warn(chalk.yellow('Warning: Could not parse connection URL, using defaults'))
+		return defaults
+	}
+}
+
+/**
+ * Create a PostgreSQL database if it doesn't exist
+ *
+ * @param {object} options - Creation options
+ * @param {string} options.dbName - Name of the database to create
+ * @param {string} options.connectionString - PostgreSQL connection string (for extracting connection params)
+ * @param {string} options.environment - Environment name (for display)
+ * @param {string} options.nextStepCommand - Command to run after creation (e.g., 'bun run db:setup')
+ */
+export async function createDatabase(options) {
+	const {
+		dbName,
+		connectionString,
+		environment = 'production',
+		nextStepCommand = 'bun run db:setup'
+	} = options
+
+	console.log(chalk.cyan(`\n🌪️  Oya Node ${environment === 'test' ? 'Test ' : ''}Database Creation\n`))
+
+	const { host, port, user, password } = parseConnectionParams(connectionString)
+
+	console.log(chalk.gray(`Target database: ${dbName}`))
+	console.log(chalk.gray(`Server: ${host}:${port}`))
+	console.log(chalk.gray(`User: ${user}\n`))
+
+	// Connect to the default 'postgres' database
+	const client = new Client({
+		host,
+		port,
+		user,
+		password,
+		database: 'postgres', // Connect to default database to create the target database
+	})
+
+	try {
+		// Test connection
+		console.log(chalk.yellow('Connecting to PostgreSQL server...'))
+		await client.connect()
+		console.log(chalk.green('✓ Connected to PostgreSQL\n'))
+
+		// Check if database already exists
+		console.log(chalk.yellow(`Checking if database '${dbName}' exists...`))
+		const checkResult = await client.query(
+			`SELECT 1 FROM pg_database WHERE datname = $1`,
+			[dbName]
+		)
+
+		if (checkResult.rows.length > 0) {
+			console.log(chalk.green(`✓ Database '${dbName}' already exists`))
+			console.log(chalk.cyan('\nDatabase is ready! You can now run:'))
+			console.log(chalk.gray(`  ${nextStepCommand}`))
+			console.log(chalk.gray(`\nTo create/update tables\n`))
+			return true
+		}
+
+		// Create the database
+		console.log(chalk.yellow(`Creating database '${dbName}'...`))
+		await client.query(`CREATE DATABASE ${dbName}`)
+		console.log(chalk.green(`✓ Database '${dbName}' created successfully!\n`))
+
+		// Show next steps
+		const suggestedUrl = `postgresql://${user}:${password}@${host}:${port}/${dbName}`
+
+		console.log(chalk.cyan(`🎉 ${environment === 'test' ? 'Test ' : ''}Database created successfully!\n`))
+		console.log(chalk.yellow('Next steps:'))
+		console.log(chalk.gray('1. Ensure your .env file has:'))
+		console.log(chalk.gray(`   ${environment === 'test' ? 'TEST_DATABASE_URL' : 'DATABASE_URL'}=${suggestedUrl}`))
+		console.log(chalk.gray('\n2. Create the tables:'))
+		console.log(chalk.gray(`   ${nextStepCommand}\n`))
+
+		return true
+
+	} catch (error) {
+		console.error(chalk.red(`\n❌ ${environment === 'test' ? 'Test ' : ''}Database creation failed:`))
+		console.error(chalk.red(error.message))
+
+		if (error.code === 'ECONNREFUSED') {
+			console.log(chalk.yellow('\nMake sure PostgreSQL is running and accessible'))
+			console.log(chalk.gray('You may need to:'))
+			console.log(chalk.gray('  - Start PostgreSQL service'))
+			console.log(chalk.gray('  - Check your connection settings'))
+			console.log(chalk.gray('  - Verify user credentials'))
+		} else if (error.code === '42P04') {
+			console.log(chalk.yellow(`\nDatabase '${dbName}' already exists`))
+		} else if (error.code === '28P01') {
+			console.log(chalk.yellow('\nAuthentication failed'))
+			console.log(chalk.gray('Check your username and password'))
+		}
+
+		throw error
+
+	} finally {
+		await client.end()
+	}
+}

--- a/scripts/shared/db-setup.js
+++ b/scripts/shared/db-setup.js
@@ -1,0 +1,195 @@
+/**
+ * ╔═══════════════════════════════════════════════════════════════════════════╗
+ * ║                        🌪️  OYA PROTOCOL NODE  🌪️                          ║
+ * ║                    Shared Database Setup Logic                            ║
+ * ╚═══════════════════════════════════════════════════════════════════════════╝
+ *
+ * Shared functions for database setup used by both production and test scripts.
+ */
+
+import pg from 'pg'
+import chalk from 'chalk'
+
+const { Pool } = pg
+
+/**
+ * SQL statements for creating tables
+ */
+export const createTablesSql = `
+-- Create the bundles table (stores bundle data with IPFS CIDs)
+CREATE TABLE IF NOT EXISTS bundles (
+  id SERIAL PRIMARY KEY,
+  bundle BYTEA NOT NULL,
+  nonce INTEGER NOT NULL,
+  proposer TEXT NOT NULL,
+  signature TEXT NOT NULL,
+  ipfs_cid TEXT,
+  timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create the cids table (tracks submitted CIDs)
+CREATE TABLE IF NOT EXISTS cids (
+  id SERIAL PRIMARY KEY,
+  cid TEXT NOT NULL,
+  nonce INTEGER NOT NULL,
+  proposer TEXT NOT NULL,
+  timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create the balances table (manages vault token balances)
+CREATE TABLE IF NOT EXISTS balances (
+  id SERIAL PRIMARY KEY,
+  vault TEXT NOT NULL,
+  token TEXT NOT NULL,
+  balance NUMERIC(78, 18) NOT NULL,
+  timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (vault, token)
+);
+
+-- Create the nonces table (tracks vault nonces)
+CREATE TABLE IF NOT EXISTS nonces (
+  id SERIAL PRIMARY KEY,
+  vault TEXT NOT NULL,
+  nonce INTEGER NOT NULL,
+  timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE (vault)
+);
+
+-- Create the proposers table (records block proposers)
+CREATE TABLE IF NOT EXISTS proposers (
+  id SERIAL PRIMARY KEY,
+  proposer TEXT NOT NULL UNIQUE,
+  last_seen TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+/**
+ * SQL statements for creating indexes
+ */
+export const createIndexesSql = `
+-- Create case-insensitive unique indexes for vault/token lookups
+CREATE UNIQUE INDEX IF NOT EXISTS unique_lower_vault_nonces ON nonces (LOWER(vault));
+CREATE UNIQUE INDEX IF NOT EXISTS unique_lower_vault_token_balances ON balances (LOWER(vault), LOWER(token));
+`
+
+/**
+ * SQL statements for dropping tables
+ */
+export const dropTablesSql = `
+DROP TABLE IF EXISTS bundles CASCADE;
+DROP TABLE IF EXISTS cids CASCADE;
+DROP TABLE IF EXISTS balances CASCADE;
+DROP TABLE IF EXISTS nonces CASCADE;
+DROP TABLE IF EXISTS proposers CASCADE;
+`
+
+/**
+ * Setup database tables and indexes
+ *
+ * @param {object} options - Setup options
+ * @param {string} options.connectionString - PostgreSQL connection string
+ * @param {boolean} options.ssl - Whether to use SSL
+ * @param {boolean} options.dropExisting - Whether to drop existing tables first
+ * @param {boolean} options.forceDropConfirm - Confirmation for dropping tables
+ * @param {string} options.environment - Environment name (for display)
+ */
+export async function setupDatabase(options) {
+	const {
+		connectionString,
+		ssl = true,
+		dropExisting = false,
+		forceDropConfirm = false,
+		environment = 'production'
+	} = options
+
+	// Create connection pool
+	const pool = new Pool({
+		connectionString,
+		ssl: ssl ? { rejectUnauthorized: false } : false,
+	})
+
+	console.log(chalk.cyan(`\n🌪️  Oya Node Database Setup (${environment})\n`))
+	console.log(chalk.gray(`Connection: ${connectionString.replace(/:[^:@]*@/, ':****@')}`))
+	console.log(chalk.gray(`SSL: ${ssl ? 'enabled' : 'disabled'}\n`))
+
+	try {
+		// Test connection
+		console.log(chalk.yellow('Testing database connection...'))
+		await pool.query('SELECT NOW()')
+		console.log(chalk.green('✓ Database connection successful\n'))
+
+		// Drop existing tables if requested
+		if (dropExisting) {
+			console.log(chalk.red('⚠️  Dropping existing tables...'))
+
+			if (!forceDropConfirm) {
+				console.log(chalk.red('\n⚠️  WARNING: This will DELETE ALL DATA in the following tables:'))
+				console.log(chalk.red('  - bundles, cids, balances, nonces, proposers'))
+				console.log(chalk.yellow('\nTo confirm, set FORCE_DROP=true or remove --drop-existing flag'))
+				await pool.end()
+				process.exit(1)
+			}
+
+			await pool.query(dropTablesSql)
+			console.log(chalk.green('✓ Existing tables dropped\n'))
+		}
+
+		// Create tables
+		console.log(chalk.yellow('Creating tables...'))
+		await pool.query(createTablesSql)
+		console.log(chalk.green('✓ Tables created successfully'))
+
+		// Create indexes
+		console.log(chalk.yellow('Creating indexes...'))
+		await pool.query(createIndexesSql)
+		console.log(chalk.green('✓ Indexes created successfully'))
+
+		// Verify tables were created
+		console.log(chalk.yellow('\nVerifying database schema...'))
+		const result = await pool.query(`
+			SELECT table_name
+			FROM information_schema.tables
+			WHERE table_schema = 'public'
+			AND table_name IN ('bundles', 'cids', 'balances', 'nonces', 'proposers')
+			ORDER BY table_name
+		`)
+
+		console.log(chalk.green('\n✓ Database setup complete!'))
+		console.log(chalk.cyan('\nTables created:'))
+		result.rows.forEach(row => {
+			console.log(chalk.gray(`  • ${row.table_name}`))
+		})
+
+		// Check if we need to update existing data to lowercase
+		const balancesCount = await pool.query('SELECT COUNT(*) FROM balances')
+		const noncesCount = await pool.query('SELECT COUNT(*) FROM nonces')
+
+		if (parseInt(balancesCount.rows[0].count) > 0 || parseInt(noncesCount.rows[0].count) > 0) {
+			console.log(chalk.yellow('\nUpdating existing data to lowercase...'))
+			await pool.query('UPDATE nonces SET vault = LOWER(vault)')
+			await pool.query('UPDATE balances SET vault = LOWER(vault), token = LOWER(token)')
+			console.log(chalk.green('✓ Existing data updated'))
+		}
+
+		console.log(chalk.green(`\n✅ ${environment} database is ready for use!\n`))
+
+		return true
+
+	} catch (error) {
+		console.error(chalk.red('\n❌ Database setup failed:'))
+		console.error(chalk.red(error.message))
+
+		if (error.code === 'ECONNREFUSED') {
+			console.log(chalk.yellow('\nMake sure PostgreSQL is running and accessible'))
+		} else if (error.code === '42P07') {
+			console.log(chalk.yellow('\nTables already exist. Use --drop-existing to recreate them'))
+		} else if (error.code === '3D000') {
+			console.log(chalk.yellow('\nDatabase does not exist. Please create it first'))
+		}
+
+		throw error
+
+	} finally {
+		await pool.end()
+	}
+}

--- a/src/config/envSchema.ts
+++ b/src/config/envSchema.ts
@@ -45,6 +45,23 @@ export const envSchema: EnvVariable[] = [
 		},
 	},
 	{
+		name: 'TEST_DATABASE_URL',
+		required: false,
+		type: 'url',
+		description:
+			'Test database connection string (auto-derived from DATABASE_URL if not set)',
+		sensitive: true,
+		validator: (value) => {
+			if (
+				!value.startsWith('postgres://') &&
+				!value.startsWith('postgresql://')
+			) {
+				return 'Must be a valid PostgreSQL connection string'
+			}
+			return true
+		},
+	},
+	{
 		name: 'DATABASE_SSL',
 		required: false,
 		type: 'boolean',

--- a/src/types/setup.ts
+++ b/src/types/setup.ts
@@ -62,6 +62,8 @@ export interface EnvironmentConfig {
 	API_BEARER_TOKEN: string
 	/** PostgreSQL connection string for the node's database */
 	DATABASE_URL: string
+	/** PostgreSQL connection string for test database (optional, auto-derived if not set) */
+	TEST_DATABASE_URL?: string
 	/** Enable SSL for database connections (default: true) */
 	DATABASE_SSL: boolean
 	/** Alchemy API key for blockchain RPC access */


### PR DESCRIPTION
  This PR adds complete test database setup scripts and infrastructure so we can easily manage test databases separately from production. Its implementation is identical to normal db setup/creation, since they now use shared scripts to build both.

New commands:
  `bun db:test:create`  # Create test database
  `bun db:test:setup`   # Setup test tables
  `bun db:test:reset`   # Drop and recreate (destructive!)

You can also do `npm run` (its backwards compatible with the old CLI, it just uses bun under the hood).


To make this work, I added `TEST_DATABASE_URL` to env schema with proper validation. It's completely optional. The default behavior is to auto-derive `TEST_DATABASE_URL` from `DATABASE_URL` by appending `_test` to db name. This is well documented in .env.example and types

  We needed a clean way to set up test databases without duplicating all the setup logic. Now both prod and test env will use the same shared functions, and developers can  easily make test dbs for upcoming tests.